### PR TITLE
feat(instances): included store_id in instances and created function …

### DIFF
--- a/api/instance.go
+++ b/api/instance.go
@@ -38,6 +38,7 @@ func (a *API) GetAppManifest(w http.ResponseWriter, r *http.Request) error {
 type InstanceRequestParams struct {
 	UUID       string              `json:"uuid"`
 	BaseConfig *conf.Configuration `json:"config"`
+	StoreID    string              `json:"store_id"`
 }
 
 type InstanceResponse struct {
@@ -65,6 +66,7 @@ func (a *API) CreateInstance(w http.ResponseWriter, r *http.Request) error {
 		ID:         uuid.NewRandom().String(),
 		UUID:       params.UUID,
 		BaseConfig: params.BaseConfig,
+		StoreID:    params.StoreID,
 	}
 	if err = a.db.CreateInstance(&i); err != nil {
 		return internalServerError("Database error creating instance").WithInternalError(err)

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -36,13 +36,14 @@ func (a *API) loadInstanceConfig(w http.ResponseWriter, r *http.Request) (contex
 		return nil, badRequestError("Operator signature missing")
 	}
 
-	instanceID := signature
-	if instanceID == "" {
-		return nil, badRequestError("Instance ID is missing")
+	storeID := signature
+	if storeID == "" {
+		return nil, badRequestError("Store ID is missing")
 	}
 
-	logEntrySetField(r, "instance_id", instanceID)
-	instance, err := a.db.GetInstance(instanceID)
+	logEntrySetField(r, "store_id", storeID)
+	instance, err := a.db.GetInstanceByStoreID(storeID)
+
 	if err != nil {
 		if models.IsNotFoundError(err) {
 			return nil, notFoundError("Unable to locate site configuration")
@@ -55,7 +56,7 @@ func (a *API) loadInstanceConfig(w http.ResponseWriter, r *http.Request) (contex
 		return nil, internalServerError("Error loading environment config").WithInternalError(err)
 	}
 
-	ctx, err = WithInstanceConfig(ctx, config, instanceID)
+	ctx, err = WithInstanceConfig(ctx, config, instance.ID)
 	if err != nil {
 		return nil, internalServerError("Error loading instance config").WithInternalError(err)
 	}

--- a/migrations/instances.sql
+++ b/migrations/instances.sql
@@ -5,5 +5,6 @@ CREATE TABLE IF NOT EXISTS `instances` (
   `base_config`      TEXT       NULL,
   `created_at`       DATETIME   NOT NULL   DEFAULT CURRENT_TIMESTAMP,
   `updated_at`       DATETIME   NULL,
-  `deleted_at`       DATETIME   NULL
+  `deleted_at`       DATETIME   NULL,
+  `store_id`         VARCHAR    NULL
 );

--- a/models/instance.go
+++ b/models/instance.go
@@ -22,6 +22,7 @@ type Instance struct {
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`
 	DeletedAt *time.Time `json:"deleted_at"`
+	StoreID   string     `json:"store_id"`
 }
 
 // TableName returns the table name used for the Instance model

--- a/storage/sql/storage.go
+++ b/storage/sql/storage.go
@@ -55,6 +55,17 @@ func (conn *Connection) GetInstance(instanceID string) (*models.Instance, error)
 	return &instance, nil
 }
 
+func (conn *Connection) GetInstanceByStoreID(storeID string) (*models.Instance, error) {
+	instance := models.Instance{}
+	if rsp := conn.db.Where("store_id = ?", storeID).First(&instance); rsp.Error != nil {
+		if rsp.RecordNotFound() {
+			return nil, models.InstanceNotFoundError{}
+		}
+		return nil, errors.Wrap(rsp.Error, "error find instance by store_id")
+	}
+	return &instance, nil
+}
+
 func (conn *Connection) GetInstanceByUUID(uuid string) (*models.Instance, error) {
 	instance := models.Instance{}
 	if rsp := conn.db.Where("uuid = ?", uuid).First(&instance); rsp.Error != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -7,6 +7,7 @@ type Connection interface {
 	Close() error
 	Automigrate() error
 
+	GetInstanceByStoreID(storeID string) (*models.Instance, error)
 	GetInstanceByUUID(uuid string) (*models.Instance, error)
 	GetInstance(instanceID string) (*models.Instance, error)
 	CreateInstance(instance *models.Instance) error


### PR DESCRIPTION
Achei melhor criar o **store_id** na tabela de instancias, antes ele ficava somente em raw_base_config que é um campo que armazena um json com outras configs, daí ficava complicado, para filtrar pelo store_id. 

**Lembrando que é preciso criar esse campo na tabela `instances`**

No **storefront_ci**, basta incluir o store_id na criação da instância. Já está sendo feito e pode ser acompanhado pela  [issue 6](https://github.com/ecomplus/storefront-ci/issues/6)